### PR TITLE
test: add router navigation spec

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,18 @@
+module.exports = {
+  moduleFileExtensions: ['js', 'json', 'vue'],
+  transform: {
+    '^.+\\.vue$': '@vue/vue2-jest',
+    '^.+\\.js$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@components/(.*)$': '<rootDir>/src/components/$1',
+    '^@views/(.*)$': '<rootDir>/src/views/$1',
+    '^@assets/(.*)$': '<rootDir>/src/assets/$1',
+    '^@styles/(.*)$': '<rootDir>/src/styles/$1',
+    '^@store/(.*)$': '<rootDir>/src/store/$1',
+    '^@router/(.*)$': '<rootDir>/src/router/$1',
+    '\\.(jpg|jpeg|png|gif|svg)$': '<rootDir>/tests/fileMock.js'
+  },
+  testEnvironment: 'jsdom'
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "test": "jest"
   },
   "dependencies": {
     "core-js": "^3.6.5",
@@ -24,6 +25,10 @@
     "eslint": "^6.7.2",
     "eslint-plugin-vue": "^6.2.2",
     "file-loader": "^6.2.0",
-    "vue-template-compiler": "^2.6.11"
+    "vue-template-compiler": "^2.6.11",
+    "@vue/test-utils": "^1.3.0",
+    "@vue/vue2-jest": "^29.2.3",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0"
   }
 }

--- a/tests/fileMock.js
+++ b/tests/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = '';

--- a/tests/router.spec.js
+++ b/tests/router.spec.js
@@ -1,0 +1,28 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import Home from '@/views/Home.vue';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('Home.vue router', () => {
+  it('pushes Courses route when course card is clicked', async () => {
+    const courses = [{ id: 1, title: 'Test', teacher: 'T', cover: '' }];
+    const store = new Vuex.Store({
+      getters: { courseList: () => courses }
+    });
+    const push = jest.fn();
+    const wrapper = mount(Home, {
+      localVue,
+      store,
+      stubs: ['Banner', 'Welcome', 'Notification'],
+      mocks: { $router: { push } }
+    });
+    const card = wrapper.find('.course-card');
+    await card.trigger('click');
+    expect(push).toHaveBeenCalledWith({
+      name: 'Courses',
+      query: { id: courses[0].id }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Home.vue router unit test
- configure Jest for Vue tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a82eca28e883318e07d43863e88b75