### PR TITLE
Fix routing order for news articles to prevent 404 errors

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -43,7 +43,6 @@ const router = new VueRouter({
     { path: '/summary', name: 'TrainSummary', component: TrainSummary },
     { path: '/circle',  name: 'StudyCircle',  component: StudyCircle },
     { path: '/news',    name: 'News',         component: News },
-    { path: '*',        name: 'NotFound',     component: NotFound },
 
     { path: '/news/article/:id', name: 'NewsArticle', component: NewsArticle },
     { path: '/news/notice/:id',  name: 'NoticeDetail', component: NoticeDetail },
@@ -65,10 +64,9 @@ const router = new VueRouter({
     { path: 'notice',   name: 'UserNotice',   component: UserNotice }
     ]
   },
+    { path: '*',        name: 'NotFound',     component: NotFound },
     // …404 等
-  
-  
-  
+
   ],
   scrollBehavior() { return { x: 0, y: 0 }; }
 });


### PR DESCRIPTION
## Summary
- ensure news article and notice routes are evaluated before the catch-all 404

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a82d03f9348331aa6f657aa5ab0217