### PR TITLE
feat: add login view and auth module

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,9 @@
+export function login(payload) {
+  return fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  }).then(res => res.json());
+}
+
+export default { login };

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -7,6 +7,7 @@ const Home         = () => import('@/views/Home.vue');
 const Theory       = () => import('@/views/Theory.vue');
 const TheoryModule = () => import('@/views/TheoryModule.vue');
 const ResourceView = () => import('@/views/ResourceView.vue');
+const Login        = () => import('@/views/auth/Login.vue');
 
 const ExamCenter   = () => import('@/views/ExamCenter.vue');   // ← 详情+开始考试
 const ExamTaking   = () => import('@/views/ExamTaking.vue');   // ← 作答页
@@ -44,8 +45,10 @@ const router = new VueRouter({
     { path: '/circle',  name: 'StudyCircle',  component: StudyCircle },
     { path: '/news',    name: 'News',         component: News },
 
-    { path: '/news/article/:id', name: 'NewsArticle', component: NewsArticle },
-    { path: '/news/notice/:id',  name: 'NoticeDetail', component: NoticeDetail },
+      { path: '/news/article/:id', name: 'NewsArticle', component: NewsArticle },
+      { path: '/news/notice/:id',  name: 'NoticeDetail', component: NoticeDetail },
+
+      { path: '/login', name: 'Login', component: Login },
     
     {
   path: '/user',
@@ -64,7 +67,7 @@ const router = new VueRouter({
     { path: 'notice',   name: 'UserNotice',   component: UserNotice }
     ]
   },
-    { path: '*',        name: 'NotFound',     component: NotFound },
+      { path: '*',        name: 'NotFound',     component: NotFound },
     // …404 等
 
   ],

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import auth from './modules/auth';
 
 Vue.use(Vuex);
 
@@ -19,5 +20,8 @@ export default new Vuex.Store({
   actions: {},
   getters: {
     courseList: s => s.courses
+  },
+  modules: {
+    auth
   }
 });

--- a/src/store/modules/auth.js
+++ b/src/store/modules/auth.js
@@ -1,0 +1,23 @@
+import { login as loginApi } from '@/api/auth';
+
+const state = () => ({
+  token: null
+});
+
+const mutations = {
+  setToken(state, token) {
+    state.token = token;
+  }
+};
+
+const actions = {
+  async login({ commit }, payload) {
+    const data = await loginApi(payload);
+    if (data && data.token) {
+      commit('setToken', data.token);
+    }
+    return data;
+  }
+};
+
+export default { namespaced: true, state, mutations, actions };

--- a/src/views/auth/Login.vue
+++ b/src/views/auth/Login.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="login">
+    <form @submit.prevent="onSubmit">
+      <div>
+        <label>用户名</label>
+        <input v-model="form.username" placeholder="请输入用户名" />
+      </div>
+      <div>
+        <label>密码</label>
+        <input type="password" v-model="form.password" placeholder="请输入密码" />
+      </div>
+      <button type="submit">登录</button>
+    </form>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex';
+
+export default {
+  name: 'Login',
+  data() {
+    return {
+      form: {
+        username: '',
+        password: ''
+      }
+    };
+  },
+  methods: {
+    ...mapActions('auth', ['login']),
+    async onSubmit() {
+      const res = await this.login(this.form);
+      if (res && res.token) {
+        this.$router.push('/');
+      } else {
+        // 可在此处理失败提示
+      }
+    }
+  }
+};
+</script>
+
+<style scoped>
+.login {
+  max-width: 320px;
+  margin: 40px auto;
+  padding: 20px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+.login label {
+  display: block;
+  margin-bottom: 4px;
+  font-weight: bold;
+}
+.login input {
+  width: 100%;
+  padding: 6px 8px;
+  margin-bottom: 12px;
+  box-sizing: border-box;
+}
+.login button {
+  width: 100%;
+  padding: 8px 0;
+  background-color: #409eff;
+  border: none;
+  color: #fff;
+  cursor: pointer;
+}
+</style>


### PR DESCRIPTION
## Summary
- add auth API login wrapper
- introduce Vuex auth module and Login view
- register login route

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a87096aff483319cffd895f4975918